### PR TITLE
Add the email and phone_number fields to the Member structure

### DIFF
--- a/json.go
+++ b/json.go
@@ -89,6 +89,8 @@ type Member struct {
 	AutoKicked   bool   `json:"autokicked,omitempty"`
 	AppInstalled bool   `json:"app_installed,omitempty"`
 	GUID         string `json:"guid,omitempty"`
+	PhoneNumber  string `json:"phone_number,omitempty"` // Only used when searching for the member to add to a group.
+	Email        string `json:"email,omitempty"`        // Only used when searching for the member to add to a group.
 }
 
 func (m Member) String() string {


### PR DESCRIPTION
These fields aren't _returned_ with any member-related calls; however,
they are used when _adding_ a member to a group.  For example, you can
add a member to a group by email address, but you need to set the "email"
property.  Ditto for "phone_number".

Example workflow:

```
import (
	"net/http"
	"strings"
	"time"

	"github.com/densestvoid/groupme"
	uuid "github.com/satori/go.uuid"
	"github.com/sirupsen/logrus"
)

// getGroupmeIDForUser returns the GroupMe ID for the given user.
// If the user could not be found, the empty string is returned.
func getGroupmeIDForUser(authorizationToken string, search string) (string, error) {
	client := groupme.NewClient(authorizationToken)

	groupSettings := groupme.GroupSettings{
		Name:  "verification-test",
		Share: false,
	}
	group, err := client.CreateGroup(groupSettings)
	if err != nil {
		logrus.Warnf("Could not create GroupMe group: %v", err)
		return "", err
	}
	logrus.Infof("Created GroupMe group: %s", group.ID.String())

	defer func() {
		logrus.Infof("Destroying GroupMe group: %s", group.ID.String())
		err = client.DestroyGroup(group.ID)
		if err != nil {
			logrus.Warnf("Could not destroy GroupMe group: %v", err)
			// Oh well.
		}
	}()

	member := &groupme.Member{
		Nickname: "verification-user",
		GUID:     uuid.NewV4().String(),
	}
	if strings.Contains(search, "@") {
		member.Email = search
	} else {
		member.PhoneNumber = search
	}
	resultsID, err := client.AddMembers(group.ID, member)
	if err != nil {
		logrus.Warnf("Could not add member to GroupMe group: %v", err)
		return "", err
	}

	logrus.Infof("Checking up on the results.")
	keepTrying := true
	for i := 0; i < 30 && keepTrying; i++ {
		logrus.Infof("Try %d", i)
		keepTrying = false

		results, err := client.AddMembersResults(group.ID, resultsID)
		if err != nil {
			if meta, okay := err.(*groupme.Meta); okay {
				logrus.Infof("GroupMe error is a Meta; code: %d", meta.Code)
				if meta.Code == http.StatusServiceUnavailable {
					keepTrying = true
					time.Sleep(500 * time.Millisecond)
					continue
				}
			} else if strings.HasPrefix(err.Error(), "503 Service Unavailable") {
				keepTrying = true
				time.Sleep(500 * time.Millisecond)
				continue
			}
			logrus.Warnf("Could not get the GroupMe results: %v", err)
			return "", err
		}
		if len(results) > 0 {
			return results[0].UserID.String(), nil
		}
	}

	// We couldn't find the user.
	return "", nil
}
```