### PR TITLE
Return Meta on error

### DIFF
--- a/client.go
+++ b/client.go
@@ -69,13 +69,16 @@ func (c Client) do(req *http.Request, i interface{}) error {
 	}
 	defer getResp.Body.Close()
 
-	bytes, err := ioutil.ReadAll(getResp.Body)
-	if err != nil {
-		return err
-	}
-
 	// Check Status Code is 1XX or 2XX
 	if getResp.StatusCode/100 > 2 {
+		bytes, err := ioutil.ReadAll(getResp.Body)
+		if err != nil {
+			// We couldn't read the output.  Oh well; generate the appropriate error type anyway.
+			return &Meta{
+				Code: HTTPStatusCode(getResp.StatusCode),
+			}
+		}
+
 		resp := newJSONResponse(nil)
 		if err := json.Unmarshal(bytes, &resp); err != nil {
 			// We couldn't parse the output.  Oh well; generate the appropriate error type anyway.
@@ -88,6 +91,11 @@ func (c Client) do(req *http.Request, i interface{}) error {
 
 	if i == nil {
 		return nil
+	}
+
+	bytes, err := ioutil.ReadAll(getResp.Body)
+	if err != nil {
+		return err
 	}
 
 	resp := newJSONResponse(i)


### PR DESCRIPTION
Previously, this would never actually return the `*Meta` data structure since by the time that it got parsed, we already knew that the request was good (and thus would return `nil`).  Now, we do a special parse when we know that it failed so that we can return the structured data (in particular, we want to be able to use the HTTP status code).

In addition, in the event of a failure response, we will still return a `*Meta` even if we can't parse the body.  From a client's perspective, being able to extract the status code is far more important than parsing whatever error messages GroupMe may have left for them.

At this point, this means that there are now three classes of error that the client can return:

1. `*Meta`; this is a "normal" error that the client can check the HTTP status code from.
2. General HTTP error (couldn't resolve, connect, etc.).
3. Read/parse error (couldn't read the body, couldn't parse the JSON).

From a workflow perspective, clients basically now have this:

```
result, err := client.XXXXXXXX(...)
if err != nil {
	if meta, okay := err.(*groupme.Meta); okay {
		logrus.Infof("GroupMe error is a Meta; code: %d", meta.Code)
		switch meta.Code {
		case http.StatusXXXXXXXX:
			// Handle this status appropriately.
		case http.StatusYYYYYYYY:
			// Handle the other status appropriately.
		default:
			// Some other status that we can't handle.
			return err
		}
	} else {
		// Some other nasty kind of error.  Probably just fail.
		return err
	}
}
```